### PR TITLE
Allow css props with no values to be shown

### DIFF
--- a/.changeset/tidy-months-decide.md
+++ b/.changeset/tidy-months-decide.md
@@ -1,0 +1,5 @@
+---
+"@ljcl/storybook-addon-cssprops": patch
+---
+
+Allow css props with no values to be shown

--- a/packages/storybook-addon-cssprops/src/components/CssPropsPanel.tsx
+++ b/packages/storybook-addon-cssprops/src/components/CssPropsPanel.tsx
@@ -14,7 +14,7 @@ export const CssPropsPanel: React.FC = () => {
   const { presetColors, disable, ...customProperties } = cssprops;
 
   const hasCustomProperties =
-    Object.values(customProperties).filter((cssprop) => !!cssprop.value)
+    Object.values(customProperties)
       .length > 0;
 
   if (!hasCustomProperties) return <NoCustomPropertiesWarning />;

--- a/packages/storybook-addon-cssprops/src/title.ts
+++ b/packages/storybook-addon-cssprops/src/title.ts
@@ -4,9 +4,7 @@ import { CssPropTypes } from "./components/CssPropsTable/types";
 
 export function useTitle(): string {
   const cssprops = useParameter<CssPropTypes>(PARAM_KEY, {});
-  const controlsCount = Object.values(cssprops).filter(
-    (cssprop) => cssprop?.value
-  ).length;
+  const controlsCount = Object.values(cssprops).length;
   const suffix = controlsCount === 0 ? "" : ` (${controlsCount})`;
   return `CSS Custom Properties${suffix}`;
 }


### PR DESCRIPTION
Without this PR, when setting a single CSS Prop with no values, it doesn't show in the `CSS Custom Properties` panel.

**Replication steps:**

- Add the following code in parameters of your story:
```ts
cssprops: {
  "css-custom-property-4": {
    // Allows us to set document a CSS Custom Property without applying anything,
    description: "The value can be left intentionally blank",
  }
}
```

**🌟 Expected result:**
<img width="711" alt="Screenshot 2022-01-20 at 14 59 02" src="https://user-images.githubusercontent.com/569053/150353302-58d02f5f-8a57-48e5-b95e-b09896498baf.png">

**🥵 Actual result:**
<img width="594" alt="Screenshot 2022-01-20 at 15 02 05" src="https://user-images.githubusercontent.com/569053/150353465-b8d600ae-057a-45e3-9cf1-b915857109aa.png">

