### PR TITLE
fix title count to exclude config keys (`presetColors`, `disable`)

### DIFF
--- a/.changeset/wicked-toes-shout.md
+++ b/.changeset/wicked-toes-shout.md
@@ -1,0 +1,5 @@
+---
+"@ljcl/storybook-addon-cssprops": minor
+---
+
+Fix the count displayed in the Panel Title to not include the non-css variable config keys

--- a/packages/storybook-addon-cssprops/src/title.ts
+++ b/packages/storybook-addon-cssprops/src/title.ts
@@ -2,9 +2,11 @@ import { useParameter } from "@storybook/api";
 import { PARAM_KEY } from "./constants";
 import { CssPropertyItemGroup } from "./components/CssPropsTable/types";
 
+const CONFIG_KEYS = ['presetColors', 'disable']
+
 export function useTitle(): string {
   const cssprops = useParameter<CssPropertyItemGroup>(PARAM_KEY, {});
-  const controlsCount = Object.values(cssprops).length;
+  const controlsCount = Object.entries(cssprops).filter((item) => !CONFIG_KEYS.includes(item[0])).length;
   const suffix = controlsCount === 0 ? "" : ` (${controlsCount})`;
   return `CSS Custom Properties${suffix}`;
 }


### PR DESCRIPTION
Fix the count displayed in the Panel Title to not include the non-css variable config keys

<img width="179" alt="image" src="https://user-images.githubusercontent.com/13529535/234489819-9b6b3a37-781e-4dd6-8f49-650130fb6099.png">
