### PR TITLE
Fix storybook crashing when visiting a story directly via URL

### DIFF
--- a/.changeset/every-buses-relax.md
+++ b/.changeset/every-buses-relax.md
@@ -1,0 +1,5 @@
+---
+"@ljcl/storybook-addon-cssprops": patch
+---
+
+Fix storybook crash when visiting a story directly

--- a/packages/storybook-addon-cssprops/src/register.tsx
+++ b/packages/storybook-addon-cssprops/src/register.tsx
@@ -15,7 +15,7 @@ addons.register(ADDON_ID, (api: API) => {
       const story = api.getCurrentStoryData();
       return (
         <AddonPanel active={!!active}>
-          <CssPropsPanel storyId={story.id} />
+          <CssPropsPanel storyId={story?.id} />
         </AddonPanel>
       );
     },


### PR DESCRIPTION
When following a direct link to a story getCurrentStoryData is initially undefined, accessing the story using `story.id` would then crash Storybook.

Resolves this by using the optional chaining operator `story?.id`